### PR TITLE
Fix bug in validation for multiple formatters

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,13 @@ module.exports = class{
     if(!isNil(key)) {
       key.split(".").forEach((formatter) => {
         if(!isNil(this.formatters[formatter])) {
-          response = this.formatters[formatter].format(response.parsed);
+          let newResponse = this.formatters[formatter].format(response.parsed);
+          response = {
+            errors: response.errors.concat(newResponse.errors),
+            formatted: newResponse.formatted,
+            parsed: newResponse.parsed,
+            valid: response.valid && newResponse.valid
+          };
         }
       });
     }

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,6 +1,6 @@
 import test from "ava";
 import FormLinker from "../";
-import { NumberFormatter, RequiredFormatter } from "form-formatters";
+import { CreditCardFormatter, NumberFormatter, RequiredFormatter } from "form-formatters";
 
 test("validate", t => {
   let fl = new FormLinker({
@@ -8,15 +8,33 @@ test("validate", t => {
       foo: null
     },
     schema: {
-      schema: {
-        foo: "string"
-      }
+      foo: "string"
     }
   });
 
   fl.validateAll();
   t.deepEqual(fl.getError("foo"), []);
   t.true(fl.isValid());
+});
+
+test("multiple formatters", t => {
+  const formatters = {
+    "cc": CreditCardFormatter,
+    "required": RequiredFormatter
+  };
+
+  let fl = new FormLinker({
+    data: {
+      cc: "1234"
+    },
+    formatters: formatters,
+    schema: {
+      cc: "cc.required"
+    }
+  });
+
+  fl.validate("cc");
+  t.deepEqual(fl.getError("cc"), ["FormFormatters.creditCardInvalid"]);
 });
 
 test("complex validate", t => {


### PR DESCRIPTION
So you can see this when setting up a schema like creditCard.required or email.required.
It was passing for the parsed data but not the error message along.
So, if it failed the email validation but there was a value, then it would pass required validation and show as valid.