### PR TITLE
Extract Differences fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ module.exports = class{
   // extractDifferences returns an object of every key that has changed with the value it has changed to. This is great for sending only changes.
   extractDifferences(original) {
     let differences = {};
-    const data = this.data;
+    const data = this.parsedData;
 
     this.fields.forEach((field) => {
       if((isNil(get(original, field)) || get(original, field) === "") && (isNil(get(data, field)) || get(data, field) === "")) {


### PR DESCRIPTION
corrected extractDifferences to compare against the parsed data instead of formatted data.

Reason for the change: by using data in extract differences you are comparing formatted data.
Using Phone as example data coming in from server is unformatted "xxx-xxx-xxxx" however data in form linker(while using phone formatter) is going to be"(xxx) xxx-xxxx". These will never equal.

It is for the example above that i think we need to change formLinker to use parsedData instead of (formatted)data. 