### PR TITLE
Fix for clearing errors with nested schema structures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const isEqual = require("lodash/isEqual");
 const isEmpty = require("lodash/isEmpty");
 const isNil = require("lodash/isNil");
 const set = require("lodash/set");
+const unset = require("lodash/unset");
 
 module.exports = class{
   constructor(options = {}) {
@@ -62,7 +63,7 @@ module.exports = class{
   // setError removes errors data if an empty array or sets the errors. It also calls the changeCallback.
   setError(fieldName, errors, triggerCallback = true) {
     if(isEmpty(errors)) {
-      delete this.errors[fieldName];
+      unset(this.errors, fieldName);
     } else {
       set(this.errors, fieldName, errors);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,18 @@ module.exports = class{
   setError(fieldName, errors, triggerCallback = true) {
     if(isEmpty(errors)) {
       unset(this.errors, fieldName);
+      let nested = fieldName.indexOf(".") > -1;
+      if(nested) {
+        let currentPath = fieldName.slice(0, fieldName.lastIndexOf("."));
+        while(currentPath) {
+          if(isEmpty(get(this.errors, currentPath))) {
+            unset(this.errors, currentPath);
+            currentPath = currentPath.slice(0, currentPath.lastIndexOf("."));
+          } else {
+            break;
+          }
+        }
+      }
     } else {
       set(this.errors, fieldName, errors);
     }

--- a/test/setError.js
+++ b/test/setError.js
@@ -21,7 +21,10 @@ test("set empty error", t => {
       foo: "bar"
     },
     schema: {
-      foo: "string"
+      foo: "string",
+      bar: {
+        baz: "string"
+      }
     }
   });
 
@@ -29,4 +32,8 @@ test("set empty error", t => {
   t.deepEqual(fl.getError("foo"), ["new bar"]);
   fl.setError("foo", []);
   t.deepEqual(fl.getError("foo"), []);
+  fl.setError("bar.baz", ["new bar"]);
+  t.deepEqual(fl.getError("bar.baz"), ["new bar"]);
+  fl.setError("bar.baz", []);
+  t.deepEqual(fl.getError("bar.baz"), []);
 });

--- a/test/setError.js
+++ b/test/setError.js
@@ -23,7 +23,9 @@ test("set empty error", t => {
     schema: {
       foo: "string",
       bar: {
-        baz: "string"
+        baz: {
+          qux: "string"
+        }
       }
     }
   });
@@ -32,8 +34,9 @@ test("set empty error", t => {
   t.deepEqual(fl.getError("foo"), ["new bar"]);
   fl.setError("foo", []);
   t.deepEqual(fl.getError("foo"), []);
-  fl.setError("bar.baz", ["new bar"]);
-  t.deepEqual(fl.getError("bar.baz"), ["new bar"]);
-  fl.setError("bar.baz", []);
-  t.deepEqual(fl.getError("bar.baz"), []);
+  fl.setError("bar.baz.qux", ["new bar"]);
+  t.deepEqual(fl.getError("bar.baz.qux"), ["new bar"]);
+  fl.setError("bar.baz.qux", []);
+  t.deepEqual(fl.getError("bar.baz.qux"), []);
+  t.deepEqual(fl.errors, {});
 });


### PR DESCRIPTION
This is a nonbreaking bug fix.

Problem: clearing errors fails when using `setError(fieldname, errors, triggerCallback)` method when `errors` is an empty array `[ ]` and `fieldname` is a compound path, i.e. "foo.bar.baz", representing a nested schema structure.

Proposed fix: instead of using the `delete` operator, use lodash's `unset` method.