### PR TITLE
Type definitions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@
 .eslintrc.js
 .git
 .gitignore
-README.md
 circle.yml
 index.js
 node_modules

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,3 @@ jobs:
             - node_modules
       - run: npm test
       - run: npm run lint
-      - run: npm run security

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,46 @@
+declare module "form-linker" {
+  export default FormLinker;
+  class FormLinker {
+    constructor(options?: {
+      data: {},
+      converters?: any;
+      formatters?: any;
+      masks?: any;
+      onChange?: () => void;
+      schema: {}
+    });
+    schema: {};
+    fields: string[];
+    converters?: any;
+    formatters?: any;
+    masks: any;
+    data: {};
+    parsedData: {};
+    originalData: {};
+    errors: {};
+    changeCallback(): void;
+    calcFields(schema?: {}, prefix?: string, fields?: string[]): string[];
+    convert(fieldName: string, value: any): any;
+    getError(fieldName: string): string[];
+    getErrors(): {};
+    setError(fieldName: string, errors: {}, triggerCallback?: boolean): void;
+    setErrors(errors: any, triggerCallback?: boolean): void;
+    getValue(fieldName: string): any;
+    getValues(): {};
+    setValue(fieldName: string, value: any, triggerCallback?: boolean): void;
+    setValues(values: any, triggerCallback?: boolean): void;
+    setValuesFromParsed(values: any): void;
+    format(fieldName: string, value: any): {
+      errors: any[];
+      formatted: any;
+      parsed: any;
+      valid: boolean;
+    };
+    mask(fieldName: string, value: any): any;
+    isValid(): boolean;
+    validate(fieldName: string, triggerCallback?: boolean): void;
+    validateAll(triggerCallback?: boolean): void;
+    extractDifferences(original: any): {};
+    updateSchema(schema: {}): void;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,28 +19,46 @@ declare module "form-linker" {
     originalData: {};
     errors: {};
     changeCallback(): void;
+    /** Used internally by FormLinker */
     calcFields(schema?: {}, prefix?: string, fields?: string[]): string[];
+    /** Used internally by FormLinker */
     convert(fieldName: string, value: any): any;
+    /** Returns current errors for a given fieldName */
     getError(fieldName: string): string[];
+    /** Returns all current errors */
     getErrors(): {};
-    setError(fieldName: string, errors: {}, triggerCallback?: boolean): void;
-    setErrors(errors: any, triggerCallback?: boolean): void;
+    /** Set the errors for specific field */
+    setError(fieldName: string, errors: string[], triggerCallback?: boolean): void;
+    /** Set errors for all fields with matching property name or path in the errors parameter */
+    setErrors(errors: {}, triggerCallback?: boolean): void;
+    /** Returns the value for a given fieldName */
     getValue(fieldName: string): any;
+    /** Returns the current data property */
     getValues(): {};
+    /** Set the value for a given fieldName. Sets the "masked" value in data and the "formatted" value in thise.parsedData values */
     setValue(fieldName: string, value: any, triggerCallback?: boolean): void;
-    setValues(values: any, triggerCallback?: boolean): void;
+    /** Set the values for all fields with matching property name or path in the values parameter. Runs setValue for each field. */
+    setValues(values: {}, triggerCallback?: boolean): void;
+    /** Like setValues, except instead of running setValue for each field, it runs it through the converters sets the result in this.data. It does not set or change this.parsedData values. */
     setValuesFromParsed(values: any): void;
+    /** Used internally by FormLinker. Runs the value through the formatter for the applicable schema type. */
     format(fieldName: string, value: any): {
-      errors: any[];
+      errors: string[];
       formatted: any;
       parsed: any;
       valid: boolean;
     };
+    /** Used internally by FormLinker */
     mask(fieldName: string, value: any): any;
+    /** Runs this.format on each field until it finds an error. Returns true if no error is found. */
     isValid(): boolean;
+    /** Validates the given field. Internally runs this.format on the given field, then updates the field's errors, data value and parsedData value */
     validate(fieldName: string, triggerCallback?: boolean): void;
+    /** Runs this.validate for every field */
     validateAll(triggerCallback?: boolean): void;
+    /** Returns an object with fieldNames and values that are different thn "original" parameter. If there are no differences returns an empty object */
     extractDifferences(original: any): {};
+    /** Updates the schema for the current FormLinker instance - used if the fieldNames change or are set dynamically */
     updateSchema(schema: {}): void;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,17 +29,17 @@ declare module "form-linker" {
     getErrors(): {};
     /** Set the errors for specific field */
     setError(fieldName: string, errors: string[], triggerCallback?: boolean): void;
-    /** Set errors for all fields with matching property name or path in the errors parameter */
+    /** Set errors for all fields with a matching property name or path in the errors object param */
     setErrors(errors: {}, triggerCallback?: boolean): void;
     /** Returns the value for a given fieldName */
     getValue(fieldName: string): any;
     /** Returns the current data property */
     getValues(): {};
-    /** Set the value for a given fieldName. Sets the "masked" value in data and the "formatted" value in thise.parsedData values */
+    /** Set the value for a given fieldName. Sets the "masked" value in this.data and the "formatted" value in this.parsedData values */
     setValue(fieldName: string, value: any, triggerCallback?: boolean): void;
     /** Set the values for all fields with matching property name or path in the values parameter. Runs setValue for each field. */
     setValues(values: {}, triggerCallback?: boolean): void;
-    /** Like setValues, except instead of running setValue for each field, it runs it through the converters sets the result in this.data. It does not set or change this.parsedData values. */
+    /** Like setValues, but instead of running setValue() for each field, it runs the values through the converters and sets the result in this.data. It does not set or change this.parsedData. */
     setValuesFromParsed(values: any): void;
     /** Used internally by FormLinker. Runs the value through the formatter for the applicable schema type. */
     format(fieldName: string, value: any): {
@@ -50,13 +50,13 @@ declare module "form-linker" {
     };
     /** Used internally by FormLinker */
     mask(fieldName: string, value: any): any;
-    /** Runs this.format on each field until it finds an error. Returns true if no error is found. */
+    /** Runs this.format on each field until it finds one with a validation error and returns false. Returns true if no error is found. */
     isValid(): boolean;
     /** Validates the given field. Internally runs this.format on the given field, then updates the field's errors, data value and parsedData value */
     validate(fieldName: string, triggerCallback?: boolean): void;
     /** Runs this.validate for every field */
     validateAll(triggerCallback?: boolean): void;
-    /** Returns an object with fieldNames and values that are different thn "original" parameter. If there are no differences returns an empty object */
+    /** Returns an object with fieldNames and values that are different than "original" parameter. If there are no differences returns an empty object */
     extractDifferences(original: any): {};
     /** Updates the schema for the current FormLinker instance - used if the fieldNames change or are set dynamically */
     updateSchema(schema: {}): void;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "scripts": {
     "lint": "eslint src",
     "build": "babel src --out-dir dist",
-    "security": "node_modules/nsp/bin/nsp check",
     "test": "ava"
   },
   "dependencies": {


### PR DESCRIPTION
Adds a type definitions file so editors can provide intellisense options and hints. This was developed and tested solely with vsCode, so I don't know if it will be as effective with other editors. But the results here are quite good. Corrections to typos and/or phrasing are welcome.

Image 1 shows the constructor profile:
![image](https://user-images.githubusercontent.com/20136005/80330981-fa123c80-8803-11ea-8ae2-175c19d284cd.png)

image 2 shows the list of available methods and properties for autocompletion
![image](https://user-images.githubusercontent.com/20136005/80330884-b586a100-8803-11ea-8abc-3688e09dc4e8.png)

image 3 shows a method description on hover:
![image](https://user-images.githubusercontent.com/20136005/80330905-c59e8080-8803-11ea-9aec-a5b5abc46d87.png)
