### PR TITLE
Custom/server validation errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,10 +52,10 @@ declare module "form-linker" {
     mask(fieldName: string, value: any): any;
     /** Runs this.format on each field until it finds one with a validation error and returns false. Returns true if no error is found. */
     isValid(): boolean;
-    /** Validates the given field. Internally runs this.format on the given field, then updates the field's errors, data value and parsedData value. Forces a rerender of the associated React component to show any errors. */
-    validate(fieldName: string, triggerCallback?: boolean): void;
-    /** Runs this.validate for every field */
-    validateAll(triggerCallback?: boolean): void;
+    /** Validates the given field. Internally runs this.format on the given field, then updates the field's errors, data value and parsedData value. Forces a rerender of the associated React component to show any errors. If "serverValidation" errors are provided, they will be merged with the formLinker validation errors. */
+    validate(fieldName: string, triggerCallback?: boolean, serverValidation?: string[]): void;
+    /** Runs this.validate for every field. If arg is an object of fieldName/error key-value pairs, it will be merged with the formLinker validation errors. */
+    validateAll(arg?: boolean | {[fieldName: string]: string[]}): void;
     /** Returns an object with fieldNames and values that are different than "original" parameter. If there are no differences returns an empty object */
     extractDifferences(original: any): {};
     /**
@@ -68,8 +68,8 @@ declare module "form-linker" {
     getRef(fieldName: string): HTMLElement;
     /** Sets focus on the input associated with fieldName */
     focusOnField(fieldName: string): void;
-    /** Runs validation on the form and scrolls to the first field in the schema/form on the page with an error. */
-    scrollToError(): void;
+    /** Runs validation on the form and scrolls to the first field in the schema/form on the page with an error. Takes an optional argument containing custom errors to be merged with the formLinker validation errors. Returns the fieldName that it scrolled to. */
+    scrollToError(errors?: {[fieldName: string]: string[]}): string;
     /** Updates the schema for the current FormLinker instance - used if the fieldNames change or are set dynamically */
     updateSchema(schema: {}): void;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,8 +68,8 @@ declare module "form-linker" {
     getRef(fieldName: string): HTMLElement;
     /** Sets focus on the input associated with fieldName */
     focusOnField(fieldName: string): void;
-    /** Runs validation on the form and scrolls to the first field in the schema/form on the page with an error. Takes an optional argument containing custom errors to be merged with the formLinker validation errors. Returns the fieldName that it scrolled to. */
-    scrollToError(errors?: {[fieldName: string]: string[]}): string;
+    /** Runs validation on the form and scrolls to the first field in the schema/form on the page with an error. Takes an optional argument containing custom errors to be merged with the formLinker validation errors. */
+    scrollToError(errors?: {[fieldName: string]: string[]}): void;
     /** Updates the schema for the current FormLinker instance - used if the fieldNames change or are set dynamically */
     updateSchema(schema: {}): void;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -334,7 +334,6 @@ export default class{
         setTimeout(() => {
           ref.blur();
           this.setError(fieldName, error);
-          return fieldName;
         });
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,6 @@ export default class{
 
     this.fields.forEach(field => {
       const error = serverValidationErrors[field];
-      console.log(field, error);
       this.validate(field, false, error);
     });
 

--- a/test/validate.js
+++ b/test/validate.js
@@ -153,3 +153,33 @@ test("complex validate", t => {
   fl.validate("foo");
   t.deepEqual(fl.getError("foo"), ["FormFormatters.required"]);
 });
+
+test("merge custom errors", t => {
+  const customErrors = {
+    "company.name": ["That name is taken"]
+  };
+
+  const formatters = {
+    required: RequiredFormatter
+  };
+
+  const fl = new FormLinker({
+    data: {
+      company: {
+        name: ""
+      }
+    },
+    formatters,
+    schema: {
+      company: {
+        name: "string.required"
+      }
+    }
+  });
+
+  fl.validateAll(customErrors);
+  t.deepEqual(fl.getError("company.name"), ["That name is taken", "FormFormatters.required"]);
+  customErrors["company.name"] = ["Name is invalid"];
+  fl.scrollToError(customErrors);
+  t.deepEqual(fl.getError("company.name"), ["Name is invalid", "FormFormatters.required"]);
+});


### PR DESCRIPTION
This PR adds the ability to set custom errors using validatAll(). While setError() and setErrors() allow for setting custom errors, subsequently running validateAll() will clear them and set only the internally generated formLinker errors. Consequently, scrollToError(), which relies on validateAll() to generate validation errors, can't scroll to a custom error.

This PR adds the ability for validateAll() to optionally take an errors object as its argument and it will merge those errors with the formLinker generated errors. scrollToError() can also take an errors object argument which it will pass to validateAll().

This PR has no breaking changes.